### PR TITLE
README: MODE_BUTTON_PIN button change

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For particulate matter sensor:
  * PMS5003 pin 5 (TX) to D1 Mini "D4" pin
 
 For mode button:
- * Button connected between D1 Mini "D7" pin (GPIO13) and GND
+ * Button connected between D1 Mini "D3" pin (GPIO0) and GND
 
 For 128x32 I2C OLED:
  * OLED VCC to D1 Mini 3.3V


### PR DESCRIPTION
Don't you just hate it when that voice at the back of your head is telling you that you forgot something, and you can't tell what it is!! I was thinking when I pushed the other PR that there was still something missing... I unfortunately noticed this AFTER assembly, so it's a good thing there is a config file ;) ... but... IT'S ALIVE now! :smile: 

I may end up doing one or two more PRs around button debouncing/state-locking and putting the OLED to sleep after inactivity once I fully come to grips the code and how I want to run this. Thanks for the great video walkthoughs btw :wink: ... wouldn't have even known these handy sensors were around without it. 

---
MODE_BUTTON_PIN was changed from D7 (GPIO13) to D3 (GPIO0).

