### PR TITLE
Fix button state tracking

### DIFF
--- a/AirQualitySensorD1Mini.ino
+++ b/AirQualitySensorD1Mini.ino
@@ -257,10 +257,8 @@ void checkModeButton()
     if (g_display_state >= NUM_OF_STATES)
     {
       g_display_state = 1;
-      return;
     } else {
       g_display_state++;
-      return;
     }
   }
 


### PR DESCRIPTION
`checkModeButton()` was returning too early, and preventing the state of the button being tracked to prevent multiple events being triggered on a single button press. So holding the button would keep rotating through the screens, rather than simply advancing to the next.