### PR TITLE
Only process MQTT messages if WiFi connected

### DIFF
--- a/AirQualitySensorD1Mini.ino
+++ b/AirQualitySensorD1Mini.ino
@@ -199,14 +199,10 @@ void setup()
   Serial.println("Connecting to WiFi");
   if (initWifi())
   {
-    OLED.println("WiFi [CONNECTED]");
     Serial.println("WiFi connected");
   } else {
-    OLED.println("WiFi [FAILED]");
     Serial.println("WiFi FAILED");
   }
-  OLED.display();
-  delay(100);
 
   pinMode(MODE_BUTTON_PIN, INPUT_PULLUP); // Pin for screen mode button
 
@@ -227,8 +223,8 @@ void loop()
     {
       reconnectMqtt();
     }
+    client.loop();  // Process any outstanding MQTT messages
   }
-  client.loop();  // Process any outstanding MQTT messages
 
   checkModeButton();
   updatePmsReadings();


### PR DESCRIPTION
Not much point processing MQTT messages if the WiFi never connected. Also removed OLED WiFi feedback and delay as it will never be visible to end user (unless you can read it in the 100 ms delay!!)